### PR TITLE
Updated logic to populate campeon dropdown values for final

### DIFF
--- a/templates/games/gameInput.html
+++ b/templates/games/gameInput.html
@@ -775,9 +775,9 @@
     $('#semi').click( function (){
         $(`span[name=teamA][id='final']`).text('')
         $(`span[name=teamB][id='final']`).text('')
-        $(`#finale option[value='teamW']`).each( function(){
-            $(this).remove();
-        })
+        // Reset any entry in the finale array.
+        $(`#finale`).empty();
+        
         hide(`q${t}`)
         for (i=1; i <= 2 ; i++) {
             resA = $(`input[name=resA][id=semi${i}]`).val()
@@ -895,15 +895,27 @@
         console.log(teamA, teamB)
         if (resA > resB) {
             showFinal('finale')
-            $(`#finale option:contains(${teamB})`).each( function(){
-                $(this).remove();
-            })
+            // if teamA won only keep teamA here.
+            $(`#finale`).empty();
+            $('#finale').append(`
+                <option value=${teamA}>${teamA}</option>
+                `)
         } else if (resA < resB) {
             showFinal('finale')
-            $(`#finale option:contains(${teamA})`).each( function(){
-                $(this).remove();
-            })
+            // if teamB won only keep teamB here.
+            $(`#finale`).empty();
+            $('#finale').append(`
+                <option value=${teamB}>${teamB}</option>
+                `)
         } else {
+            // If it is a tie keep both teams.
+            $(`#finale`).empty();
+            $('#finale').append(`
+                <option value=${teamA}>${teamA}</option>
+                `)
+            $('#finale').append(`
+                <option value=${teamB}>${teamB}</option>
+            `)
             showFinal('finale')
         }
     })


### PR DESCRIPTION
Resets the dropdown entries for the final each time the semi final is updated.
Updates the dropdown on the final: if a team wins only that team is available in the dropdown. If the final ends in a tie. Both teams are there.

![dropdown teamA wins final](https://user-images.githubusercontent.com/1038197/201547687-a4a82a64-c4b1-44a5-8811-6f43c4da3e7d.png)
![dropdown teamB wins final](https://user-images.githubusercontent.com/1038197/201547690-e482d90e-abd7-4edc-bb7f-5e0cc49419e8.png)
![dropdown tie final](https://user-images.githubusercontent.com/1038197/201547695-5bc10e8a-20a8-4761-bb6e-ad4c3b3d3fc0.png)
